### PR TITLE
[FIX] web_pwa_oca : do not raise an error if service workers is disabled (only log). Otherwise, odoo is unavailable in private mode with Firefox Browser

### DIFF
--- a/web_pwa_oca/readme/ROADMAP.rst
+++ b/web_pwa_oca/readme/ROADMAP.rst
@@ -33,3 +33,4 @@
   doesn't send the cookie and web manifest returns 404.
 * Evaluate to support 'require' system.
 * Firefox can't detect 'standalone' mode. See https://bugzilla.mozilla.org/show_bug.cgi?id=1285858
+* Firefox disable service worker in private mode. See https://bugzilla.mozilla.org/show_bug.cgi?id=1601916

--- a/web_pwa_oca/static/src/js/pwa_manager.js
+++ b/web_pwa_oca/static/src/js/pwa_manager.js
@@ -17,11 +17,13 @@ odoo.define("web_pwa_oca.PWAManager", function (require) {
         init: function () {
             this._super.apply(this, arguments);
             if (!('serviceWorker' in navigator)) {
-                throw new Error(
-                    _t("Service workers are not supported! Maybe you are not using HTTPS?"));
+                console.error(
+                    _t("Service workers are not supported! Maybe you are not using HTTPS or you work in private mode."));
             }
-            this._service_worker = navigator.serviceWorker;
-            this.registerServiceWorker('/service-worker.js');
+            else {
+                this._service_worker = navigator.serviceWorker;
+                this.registerServiceWorker('/service-worker.js');
+            }
         },
 
         /**


### PR DESCRIPTION
Rational : 

since recent refactor of web_pwa_oca (*), odoo crashes in the following context : on firefox with private mode.


No problem in the design of the module in my opinion, but it seems to be a Firefox limitation. see : https://bugzilla.mozilla.org/show_bug.cgi?id=1601916

**Before that patch**
- a ``throw new Error`` is done. 
- Odoo can not be used in Firefox private mode

![image](https://user-images.githubusercontent.com/3407482/101893165-aabb2980-3ba4-11eb-8cea-8e39c594e5f9.png)


**With that patch**
- an error is logged.
- Odoo can be used in Firefox private mode
![image](https://user-images.githubusercontent.com/3407482/101893252-ca525200-3ba4-11eb-8e71-a8cc05b6df15.png)


(*) Maybe here https://github.com/OCA/web/pull/1628, it was working some weeks ago...
